### PR TITLE
chore: Bump cdk8s-datadog from 0.0.2 to 0.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ yarn
 
 alias pj="npx projen@latest"
 pj build
-pj synth
 ```
 
 ## Deploy

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@vincentgna/cdk8s-datadog": "^0.0.2",
+    "@vincentgna/cdk8s-datadog": "^0.0.3",
     "cdk8s": "^2.3.33",
     "cdk8s-plus-25": "^2.0.0-rc.26",
     "constructs": "^10.1.42"

--- a/src/SampleChart.ts
+++ b/src/SampleChart.ts
@@ -89,15 +89,10 @@ export class SampleChart extends Chart {
 
     // Trigger alert if CPU usage isn't resolved by autoscaling
     new DatadogMonitor(this, "CpuUtilizationMonitor", {
-      metadata: {
-        name: `${deployment.name}-cpu-utilisation`,
-      },
-      spec: {
-        name: "[CDK8s] podinfo pod cpu utilisation is too high, review Autoscaling triggers",
-        type: "metric alert",
-        query: `avg(last_5m):sum:docker.cpu.usage{kube_deployment:${deployment.name}} > ${cpuMonitorThreshold}`,
-        message: `CPU Usage over ${cpuMonitorThreshold} for the last 5min`,
-      },
+      name: "[CDK8s] podinfo pod cpu utilisation is too high",
+      type: "metric alert",
+      query: `avg(last_5m):sum:docker.cpu.usage{kube_deployment:${deployment.name}} > ${cpuMonitorThreshold}`,
+      message: `CPU Usage over ${cpuMonitorThreshold} for the last 5min, review Autoscaling triggers`,
     });
     const service = deployment.exposeViaService();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1217,10 +1217,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@vincentgna/cdk8s-datadog@^0.0.2":
-  version "0.0.2"
-  resolved "https://npm.pkg.github.com/download/@vincentgna/cdk8s-datadog/0.0.2/795af2d6f64ccdcea17db6c0bc8fceb60b3998a5#795af2d6f64ccdcea17db6c0bc8fceb60b3998a5"
-  integrity sha512-oPvV6Q4/r566C4sa8AS/tDgZQv4TUkLkXvAxYRBbuSAxqTi4UfLty50VPPi6JDXgRZeF4RCpLrUC/TRIkG83xA==
+"@vincentgna/cdk8s-datadog@^0.0.3":
+  version "0.0.3"
+  resolved "https://npm.pkg.github.com/download/@vincentgna/cdk8s-datadog/0.0.3/26ab470f1f9862791b1da7d73def767d76ca6366#26ab470f1f9862791b1da7d73def767d76ca6366"
+  integrity sha512-Ly5vS9lNDO6uskIB4oaSrmv/j4E51aqvR8LkA6Tli4IoW7eSLvNOvXsaymwxOA5YP0i2/hQeayYRQ5ZwLx/BBw==
 
 "@xmldom/xmldom@^0.8.10":
   version "0.8.10"


### PR DESCRIPTION
- Use strongly typed DatadogMonitor props
